### PR TITLE
Updates to use our forked jsonparse library

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+      {
+          "type": "node",
+          "request": "launch",
+          "name": "Current JS File",
+          "program": "${workspaceFolder}/${relativeFile}",
+          "outFiles": [
+              "${workspaceFolder}/**/.js"
+          ]
+      }
+  ]
+}

--- a/index.js
+++ b/index.js
@@ -14,6 +14,11 @@ var bufferFrom = Buffer.from && Buffer.from !== Uint8Array.from
 
 */
 
+/**
+ * @param {(string|Array)} path
+ * @param {Function} map
+ * @param {Object} options possible options: {parseNumbersAsStrings: boolean}
+ */
 exports.parse = function (path, map, options) {
   var header, footer
   var parser = new Parser(options)

--- a/index.js
+++ b/index.js
@@ -14,9 +14,9 @@ var bufferFrom = Buffer.from && Buffer.from !== Uint8Array.from
 
 */
 
-exports.parse = function (path, map) {
+exports.parse = function (path, map, options) {
   var header, footer
-  var parser = new Parser()
+  var parser = new Parser(options)
   var stream = through(function (chunk) {
     if('string' === typeof chunk)
       chunk = bufferFrom ? Buffer.from(chunk) : new Buffer(chunk)

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,8 +117,8 @@
       }
     },
     "jsonparse": {
-      "version": "git+https://github.com/roirevolution/jsonparse.git#828317897e3310ad073207935a86d3f27cf85d2b",
-      "from": "git+https://github.com/roirevolution/jsonparse.git"
+      "version": "git+https://github.com/roirevolution/jsonparse.git#3eb643d06e59258e20d54fdc36336fb0174841f0",
+      "from": "git+https://github.com/roirevolution/jsonparse.git#semver:2.0.0"
     },
     "lru-cache": {
       "version": "2.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,310 @@
+{
+  "name": "JSONStream",
+  "version": "1.3.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "assertions": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/assertions/-/assertions-2.2.4.tgz",
+      "integrity": "sha1-gzSaVndNckbk+7bV4v8PUq15Hz8=",
+      "dev": true,
+      "requires": {
+        "fomatto": "0.5",
+        "render": "0.1",
+        "traverser": "1"
+      },
+      "dependencies": {
+        "fomatto": {
+          "version": "0.5.0",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
+    "curry": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/curry/-/curry-0.0.4.tgz",
+      "integrity": "sha1-F1DVGNkZxE89N/9E7caT3h8NX8s=",
+      "dev": true
+    },
+    "deep-equal": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+      "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
+      "dev": true
+    },
+    "defined": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+      "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
+      "dev": true
+    },
+    "event-stream": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-0.7.0.tgz",
+      "integrity": "sha1-LQ0SQS4KJPVmQXZpMrlVhxjgAB8=",
+      "dev": true,
+      "requires": {
+        "optimist": "0.2"
+      }
+    },
+    "fomatto": {
+      "version": "git://github.com/BonsaiDen/Fomatto.git#468666f600b46f9067e3da7200fd9df428923ea6",
+      "from": "git://github.com/BonsaiDen/Fomatto.git#468666f600b46f9067e3da7200fd9df428923ea6",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "dev": true,
+      "requires": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "it-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/it-is/-/it-is-1.0.3.tgz",
+      "integrity": "sha1-RpcAgZg4pGVu1PF2lT9b/PU/SDs=",
+      "dev": true,
+      "requires": {
+        "assertions": "~2.3.1",
+        "render": "~0.1.4",
+        "style": "0.1.x",
+        "traverser": "0.0.x",
+        "trees": "0.0.x"
+      },
+      "dependencies": {
+        "assertions": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/assertions/-/assertions-2.3.4.tgz",
+          "integrity": "sha1-qUM87R/OV8yZmvCWXRAI6WwnluY=",
+          "dev": true,
+          "requires": {
+            "fomatto": "git://github.com/BonsaiDen/Fomatto.git#468666f600b46f9067e3da7200fd9df428923ea6",
+            "render": "0.1",
+            "traverser": "1"
+          },
+          "dependencies": {
+            "traverser": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/traverser/-/traverser-1.0.0.tgz",
+              "integrity": "sha1-b1nlgTdZruqzZGuPRRP9SmLk/iA=",
+              "dev": true,
+              "requires": {
+                "curry": "0.0.x"
+              }
+            }
+          }
+        },
+        "traverser": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/traverser/-/traverser-0.0.5.tgz",
+          "integrity": "sha1-xm84xFagwhqIAUsSI1gMfr4GMes=",
+          "dev": true,
+          "requires": {
+            "curry": "0.0.x"
+          }
+        }
+      }
+    },
+    "jsonparse": {
+      "version": "git+https://github.com/roirevolution/jsonparse.git#828317897e3310ad073207935a86d3f27cf85d2b",
+      "from": "git+https://github.com/roirevolution/jsonparse.git"
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      }
+    },
+    "object-inspect": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
+      "integrity": "sha1-9RV8EWwUVbJDsG7pdwM5LFrYn+w=",
+      "dev": true
+    },
+    "optimist": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz",
+      "integrity": "sha1-6YGrfiaLRXlIWTtVZ0wJmoFcrDE=",
+      "dev": true,
+      "requires": {
+        "wordwrap": ">=0.0.1 <0.1.0"
+      }
+    },
+    "render": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/render/-/render-0.1.4.tgz",
+      "integrity": "sha1-z7M6NOJgaFkdQYRp4j2Mxc4c7/U=",
+      "dev": true,
+      "requires": {
+        "traverser": "0.0.x"
+      },
+      "dependencies": {
+        "traverser": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/traverser/-/traverser-0.0.5.tgz",
+          "integrity": "sha1-xm84xFagwhqIAUsSI1gMfr4GMes=",
+          "dev": true,
+          "requires": {
+            "curry": "0.0.x"
+          }
+        }
+      }
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "requires": {
+        "through": "~2.3.4"
+      }
+    },
+    "should": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
+      "dev": true,
+      "requires": {
+        "should-equal": "^2.0.0",
+        "should-format": "^3.0.3",
+        "should-type": "^1.4.0",
+        "should-type-adaptors": "^1.0.1",
+        "should-util": "^1.0.0"
+      }
+    },
+    "should-equal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+      "dev": true,
+      "requires": {
+        "should-type": "^1.4.0"
+      }
+    },
+    "should-format": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+      "dev": true,
+      "requires": {
+        "should-type": "^1.3.0",
+        "should-type-adaptors": "^1.0.1"
+      }
+    },
+    "should-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
+      "dev": true
+    },
+    "should-type-adaptors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+      "dev": true,
+      "requires": {
+        "should-type": "^1.3.0",
+        "should-util": "^1.0.0"
+      }
+    },
+    "should-util": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+      "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "style": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/style/-/style-0.1.1.tgz",
+      "integrity": "sha1-4vq2WxuB0+AOvK2FTMWEuiMfJW0=",
+      "dev": true,
+      "requires": {
+        "curry": "0.0.x"
+      }
+    },
+    "tape": {
+      "version": "2.12.3",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-2.12.3.tgz",
+      "integrity": "sha1-VVnVRUBQKSYnU3wBKZHsaXH2YVY=",
+      "dev": true,
+      "requires": {
+        "deep-equal": "~0.2.0",
+        "defined": "~0.0.0",
+        "glob": "~3.2.9",
+        "inherits": "~2.0.1",
+        "object-inspect": "~0.4.0",
+        "resumer": "~0.0.0",
+        "through": "~2.3.4"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "traverser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/traverser/-/traverser-1.0.0.tgz",
+      "integrity": "sha1-b1nlgTdZruqzZGuPRRP9SmLk/iA=",
+      "dev": true,
+      "requires": {
+        "curry": "0.0.x"
+      }
+    },
+    "trees": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/trees/-/trees-0.0.4.tgz",
+      "integrity": "sha1-L1H9m19khvcyyX4R7nVmcja+HVk=",
+      "dev": true,
+      "requires": {
+        "should": ">=0.0.4",
+        "style": "0.1.x",
+        "traverser": "0.0.x"
+      },
+      "dependencies": {
+        "traverser": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/traverser/-/traverser-0.0.5.tgz",
+          "integrity": "sha1-xm84xFagwhqIAUsSI1gMfr4GMes=",
+          "dev": true,
+          "requires": {
+            "curry": "0.0.x"
+          }
+        }
+      }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "parsing"
   ],
   "dependencies": {
-    "jsonparse": "^1.2.0",
+    "jsonparse": "git+https://github.com/roirevolution/jsonparse.git",
     "through": ">=2.2.7 <3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "parsing"
   ],
   "dependencies": {
-    "jsonparse": "git+https://github.com/roirevolution/jsonparse.git",
+    "jsonparse": "git+https://github.com/roirevolution/jsonparse.git#semver:2.0.0",
     "through": ">=2.2.7 <3"
   },
   "devDependencies": {

--- a/test/parseNumbersAsString.js
+++ b/test/parseNumbersAsString.js
@@ -1,0 +1,51 @@
+const test = require('tape')
+const fs = require('fs')
+const join = require('path').join
+const file = join(__dirname, 'fixtures','numbers.json')
+const JSONStream = require('../')
+
+const jsonNumbers = [
+  '12',
+  '234234',
+  '319845792347891723489716348961893468179364891236487123874618237461789236481236748891223234233'
+]
+
+test('parse numbers as strings', t => {
+  const actual = []
+  const parser = JSONStream.parse('*', null, {parseNumbersAsStrings: true})
+
+  parser.on('data', value => {
+    actual.push(value)
+  })
+  parser.on('end', () => {
+    t.deepEqual(actual, jsonNumbers)
+
+    t.end()
+  })
+
+  parser.write(`[${jsonNumbers.join(',')}]`)
+  parser.end()
+})
+
+test('throws when attempting to parse an unsafely precise number', t => {
+  let errorCount = 0
+  let dataCount = 0
+  const parser = JSONStream.parse('*')
+    .on('data', data => {
+      t.equals(data, Number(jsonNumbers[dataCount]))
+      dataCount++
+    })
+    .on('error', e => {
+      errorCount++
+      t.assert(e.message.match(/unsafe to parse as a number/), 'correct error thrown')
+    })
+    .on('end', () => {
+      t.equal(dataCount, 2)
+      t.equal(errorCount, 1)
+
+      t.end()
+    })
+
+  parser.write(`[${jsonNumbers.join(',')}]`)
+  parser.end()
+})


### PR DESCRIPTION
Updates the `jsonparse` dependency to use our fork and adds support for the new `parseNumbersAsStrings` option.

Also adds some test.